### PR TITLE
Fix SQLite INSERT statement in create_device function

### DIFF
--- a/util/db_sqlite.py
+++ b/util/db_sqlite.py
@@ -34,7 +34,7 @@ def create_device(entry):
     cursor = connection.execute(
         '''
         INSERT INTO devices (id, code, refresh, token, settings, user_agent)
-        VALUES (?1, ?2, ?3, ?4)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
         RETURNING id, code, refresh, token, settings, user_agent
         ''',
         [


### PR DESCRIPTION
## Description
Fixed a bug in the `create_device` function in `util/db_sqlite.py` where the INSERT statement had only 4 placeholders (`?1, ?2, ?3, ?4`) but 6 values were being passed (id, code, refresh, token, settings, user_agent).

## Problem
This was causing the following error:
```
sqlite3.OperationalError: 4 values for 6 columns
```

## Solution
Changed `VALUES (?1, ?2, ?3, ?4)` to `VALUES (?1, ?2, ?3, ?4, ?5, ?6)` to match the 6 columns and 6 values being inserted.

## Testing
Tested on a live server - the error no longer occurs and device creation works correctly.

## Changes
- Modified `util/db_sqlite.py` line 37 to include all 6 placeholders